### PR TITLE
Pythonの標準出力をhookしてrendererのイベントを発火させる

### DIFF
--- a/main.js
+++ b/main.js
@@ -37,10 +37,7 @@ app.whenReady().then(() => {
   });
 
   ipcMain.handle('run_py', async (e) => {
-    res = await run_py()
-    if (res.success == true) {
-      return res.results
-    }
+    await run_py()
   });
 })
 

--- a/main.js
+++ b/main.js
@@ -36,8 +36,8 @@ app.whenReady().then(() => {
     return get_images_and_dirs(path)
   });
 
-  ipcMain.handle('run_py', async (e) => {
-    await run_py()
+  ipcMain.handle('run_py', (e) => {
+    run_py()
   });
 })
 

--- a/preload.js
+++ b/preload.js
@@ -17,7 +17,7 @@ window.addEventListener('DOMContentLoaded', () => {
 contextBridge.exposeInMainWorld('api', {
   getImagesAndDirs: (path) => ipcRenderer.invoke('get_images_and_dirs', path),
   runPy: () => ipcRenderer.invoke('run_py'),
-  onReceiveMessage: (listener) => {
+  addEventListenerFromPython: (listener) => {
     ipcRenderer.on(
       "message-from-python",
       (event, message) => listener(message),

--- a/preload.js
+++ b/preload.js
@@ -19,13 +19,13 @@ contextBridge.exposeInMainWorld('api', {
   runPy: () => ipcRenderer.invoke('run_py'),
   addListenerOnPythonMessage: (listener) => {
     ipcRenderer.on(
-      "message-from-python",
+      "python-message",
       (event, message) => listener(message),
     );
   },
   addListenerOnPythonEnd: (listener) => {
     ipcRenderer.on(
-      "end-python",
+      "python-end",
       (event, code, signal) => listener(code, signal),
     );
   },

--- a/preload.js
+++ b/preload.js
@@ -23,4 +23,10 @@ contextBridge.exposeInMainWorld('api', {
       (event, message) => listener(message),
     );
   },
+  addListenerOnPythonEnd: (listener) => {
+    ipcRenderer.on(
+      "end-python",
+      (event, code, signal) => listener(code, signal),
+    );
+  },
 });

--- a/preload.js
+++ b/preload.js
@@ -17,7 +17,7 @@ window.addEventListener('DOMContentLoaded', () => {
 contextBridge.exposeInMainWorld('api', {
   getImagesAndDirs: (path) => ipcRenderer.invoke('get_images_and_dirs', path),
   runPy: () => ipcRenderer.invoke('run_py'),
-  addEventListenerFromPython: (listener) => {
+  addListenerOnPythonMessage: (listener) => {
     ipcRenderer.on(
       "message-from-python",
       (event, message) => listener(message),

--- a/preload.js
+++ b/preload.js
@@ -17,4 +17,10 @@ window.addEventListener('DOMContentLoaded', () => {
 contextBridge.exposeInMainWorld('api', {
   getImagesAndDirs: (path) => ipcRenderer.invoke('get_images_and_dirs', path),
   runPy: () => ipcRenderer.invoke('run_py'),
+  onReceiveMessage: (listener) => {
+    ipcRenderer.on(
+      "message-from-python",
+      (event, message) => listener(message),
+    );
+  },
 });

--- a/py/hello.py
+++ b/py/hello.py
@@ -1,2 +1,7 @@
+import time
+
 print('hello world by Python')
+
+time.sleep(1)
+
 print('hello world by Python(2)')

--- a/renderer.js
+++ b/renderer.js
@@ -3,17 +3,13 @@ window.addEventListener('DOMContentLoaded', () => {
   document.getElementById('run_py_button').addEventListener('click', (e) => {
     onClickRunPythonButton()
   })
+  window.api.onReceiveMessage(listener)
 })
 
 const onClickRunPythonButton = async () => {
   const resultListElem = document.getElementById('py_result_list')
   resultListElem.innerHTML = ""
-  const results = await window.api.runPy();
-  results.forEach((result) => {
-    const element = document.createElement('li')
-    element.innerText = result
-    resultListElem.appendChild(element)
-  })
+  window.api.runPy();
 }
 
 const showFileList = async () => {
@@ -57,4 +53,11 @@ const onClickFileName = async (e) => {
     imageListElem.style.display = "none"
     imageElem.src = e.target.dataset.fullPath
   }
+}
+
+const listener = (message) => { 
+  const resultListElem = document.getElementById('py_result_list')
+  const element = document.createElement('li')
+  element.innerText = message
+  resultListElem.appendChild(element)
 }

--- a/renderer.js
+++ b/renderer.js
@@ -4,6 +4,7 @@ window.addEventListener('DOMContentLoaded', () => {
     onClickRunPythonButton()
   })
   window.api.addListenerOnPythonMessage(onPythonMessage)
+  window.api.addListenerOnPythonEnd(onPythonEnd)
 })
 
 /**
@@ -66,5 +67,15 @@ const onPythonMessage = (message) => {
   const resultListElem = document.getElementById('py_result_list')
   const element = document.createElement('li')
   element.innerText = message
+  resultListElem.appendChild(element)
+}
+
+/**
+ * Pythonプログラムが終了したときに発火するイベント
+ */
+ const onPythonEnd = (code, signal) => { 
+  const resultListElem = document.getElementById('py_result_list')
+  const element = document.createElement('li')
+  element.innerText = "終了しました. 終了コード: " + code;
   resultListElem.appendChild(element)
 }

--- a/renderer.js
+++ b/renderer.js
@@ -6,7 +6,11 @@ window.addEventListener('DOMContentLoaded', () => {
   window.api.onReceiveMessage(listener)
 })
 
-const onClickRunPythonButton = async () => {
+/**
+ * Pythonプログラムの実行命令
+ * レンダラプロセスではawaitしない(Pythonプロセスの終了を待たない)
+ */
+const onClickRunPythonButton = () => {
   const resultListElem = document.getElementById('py_result_list')
   resultListElem.innerHTML = ""
   window.api.runPy();
@@ -55,6 +59,9 @@ const onClickFileName = async (e) => {
   }
 }
 
+/**
+ * Pythonプログラムから message が送信されたタイミングで発火するイベント
+ */
 const listener = (message) => { 
   const resultListElem = document.getElementById('py_result_list')
   const element = document.createElement('li')

--- a/renderer.js
+++ b/renderer.js
@@ -8,7 +8,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
 /**
  * Pythonプログラムの実行命令
- * レンダラプロセスではawaitしない(Pythonプロセスの終了を待たない)
+ * awaitしない(Pythonプロセスの終了を待たない)
  */
 const onClickRunPythonButton = () => {
   const resultListElem = document.getElementById('py_result_list')

--- a/renderer.js
+++ b/renderer.js
@@ -3,7 +3,7 @@ window.addEventListener('DOMContentLoaded', () => {
   document.getElementById('run_py_button').addEventListener('click', (e) => {
     onClickRunPythonButton()
   })
-  window.api.addEventListenerFromPython(listener)
+  window.api.addListenerOnPythonMessage(onPythonMessage)
 })
 
 /**
@@ -62,7 +62,7 @@ const onClickFileName = async (e) => {
 /**
  * Pythonプログラムから message が送信されたタイミングで発火するイベント
  */
-const listener = (message) => { 
+const onPythonMessage = (message) => { 
   const resultListElem = document.getElementById('py_result_list')
   const element = document.createElement('li')
   element.innerText = message

--- a/renderer.js
+++ b/renderer.js
@@ -3,7 +3,7 @@ window.addEventListener('DOMContentLoaded', () => {
   document.getElementById('run_py_button').addEventListener('click', (e) => {
     onClickRunPythonButton()
   })
-  window.api.onReceiveMessage(listener)
+  window.api.addEventListenerFromPython(listener)
 })
 
 /**

--- a/run_py.js
+++ b/run_py.js
@@ -1,7 +1,7 @@
 const { PythonShell } = require('python-shell');
 const { webContents } = require('electron')
 
-const run_py = async () => {
+const run_py = () => {
   let pyshell = new PythonShell('./py/hello.py', {pythonOptions: ['-u']});
   const webcontent = webContents.getAllWebContents()[0]
 

--- a/run_py.js
+++ b/run_py.js
@@ -8,6 +8,14 @@ const run_py = () => {
   pyshell.on('message', function (message) {
     webcontent.send("message-from-python", message)
   });
+
+  pyshell.end(function (err,code,signal) {
+    if (err) throw err;
+    console.log('The exit code was: ' + code);
+    console.log('The exit signal was: ' + signal);
+    console.log('finished');
+    webcontent.send("end-python", code, signal)
+  });
 }
 
 module.exports = {

--- a/run_py.js
+++ b/run_py.js
@@ -1,14 +1,14 @@
 const { PythonShell } = require('python-shell');
+const { webContents } = require('electron')
 
+const run_py = async () => {
+  let pyshell = new PythonShell('./py/hello.py', {pythonOptions: ['-u']});
+  const webcontent = webContents.getAllWebContents()[0]
 
-const run_py = async () => await new Promise(
-  (resolve, reject) => {
-    PythonShell.run('./py/hello.py', {}, function (err, results) {
-      if (err) reject({ success: false, err });
-      resolve({ success: true, results });
-    });
-  }
-)
+  pyshell.on('message', function (message) {
+    webcontent.send("message-from-python", message)
+  });
+}
 
 module.exports = {
   run_py

--- a/run_py.js
+++ b/run_py.js
@@ -6,7 +6,7 @@ const run_py = () => {
   const webcontent = webContents.getAllWebContents()[0]
 
   pyshell.on('message', function (message) {
-    webcontent.send("message-from-python", message)
+    webcontent.send("python-message", message)
   });
 
   pyshell.end(function (err,code,signal) {
@@ -14,7 +14,7 @@ const run_py = () => {
     console.log('The exit code was: ' + code);
     console.log('The exit signal was: ' + signal);
     console.log('finished');
-    webcontent.send("end-python", code, signal)
+    webcontent.send("python-end", code, signal)
   });
 }
 


### PR DESCRIPTION
# 背景
 - 元々の run_py は、Pythonのプロセスが終了したタイミングでまとめて標準出力をNodeのプロセスに渡すようになっているが、これでは使い勝手が悪い
 - これを、バックグラウンドで実行しているPythonのプロセスから、標準出力を受け取ったタイミングでElectronのメインプロセスやレンダラプロセスのイベントを発火させるようにする

# エビデンス
<video src="https://user-images.githubusercontent.com/13075237/144697739-dbf5fb65-e4b7-4a8f-8bae-25e2344cbb84.mp4">
