### PR TITLE
ダイアログで選択したディレクトリを展開できるようにする

### DIFF
--- a/dialog.js
+++ b/dialog.js
@@ -1,0 +1,21 @@
+const { dialog, BrowserWindow } = require('electron')
+
+const selectDirectory = () => {
+  const window = BrowserWindow.getAllWindows()[0]
+  /**
+   * return {
+   *   canceled: bool
+   *   filePaths: Array<string>
+   * }
+   */
+  let filenames = dialog.showOpenDialog(window, {
+      properties: ['openDirectory'],
+      title: 'ディレクトリを選択してください',
+      defaultPath: '.',
+  });
+  return filenames
+}
+
+module.exports = {
+  selectDirectory
+}

--- a/dialog.js
+++ b/dialog.js
@@ -1,19 +1,18 @@
 const { dialog, BrowserWindow } = require('electron')
 
-const selectDirectory = () => {
+const selectDirectory = async () => {
   const window = BrowserWindow.getAllWindows()[0]
-  /**
-   * return {
-   *   canceled: bool
-   *   filePaths: Array<string>
-   * }
-   */
-  let filenames = dialog.showOpenDialog(window, {
+  const filenames = await dialog.showOpenDialog(window, {
       properties: ['openDirectory'],
       title: 'ディレクトリを選択してください',
       defaultPath: '.',
   });
-  return filenames
+  const path = filenames.canceled ? null : filenames.filePaths[0];
+  const response = {
+    'canceled': filenames.canceled,
+    'path': path,
+  }
+  return response
 }
 
 module.exports = {

--- a/dialog.js
+++ b/dialog.js
@@ -8,11 +8,7 @@ const selectDirectory = async () => {
       defaultPath: '.',
   });
   const path = filenames.canceled ? null : filenames.filePaths[0];
-  const response = {
-    'canceled': filenames.canceled,
-    'path': path,
-  }
-  return response
+  return path
 }
 
 module.exports = {

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <button id="run_py_button">Run Python</button>
 
     <h1>Viewer</h1>
+    <button id="select_dir_button">select dir</button>
     <p>cuurent dir: <span id="dir_name"></span></p>
     <!-- このプロセスで他ファイルを require して実行することもできます -->
     <script src="./renderer.js"></script>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <button id="run_py_button">Run Python</button>
 
     <h1>Viewer</h1>
-    <button id="select_dir_button">select dir</button>
+    <button id="select_dir_button">Select Dir</button>
     <p>cuurent dir: <span id="dir_name"></span></p>
     <!-- このプロセスで他ファイルを require して実行することもできます -->
     <script src="./renderer.js"></script>

--- a/main.js
+++ b/main.js
@@ -39,6 +39,11 @@ app.whenReady().then(() => {
   ipcMain.handle('run_py', (e) => {
     run_py()
   });
+
+  ipcMain.handle('select_directory', (e) => {
+    return selectDirectory()
+  });
+
 })
 
 // macOS を除き、全ウインドウが閉じられたときに終了します。 ユーザーが
@@ -53,3 +58,4 @@ app.on('window-all-closed', () => {
 // 別々のファイルに分割してここで require することもできます。
 const { get_images_and_dirs } = require('./file')
 const { run_py } = require('./run_py')
+const { selectDirectory } = require('./dialog')

--- a/main.js
+++ b/main.js
@@ -36,14 +36,13 @@ app.whenReady().then(() => {
     return get_images_and_dirs(path)
   });
 
+  ipcMain.handle('select_directory', async (e) => {
+    return await selectDirectory()
+  });
+
   ipcMain.handle('run_py', (e) => {
     run_py()
   });
-
-  ipcMain.handle('select_directory', (e) => {
-    return selectDirectory()
-  });
-
 })
 
 // macOS を除き、全ウインドウが閉じられたときに終了します。 ユーザーが

--- a/preload.js
+++ b/preload.js
@@ -16,6 +16,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
 contextBridge.exposeInMainWorld('api', {
   getImagesAndDirs: (path) => ipcRenderer.invoke('get_images_and_dirs', path),
+  selectDirectory: () => ipcRenderer.invoke('select_directory'),
   runPy: () => ipcRenderer.invoke('run_py'),
   addListenerOnPythonMessage: (listener) => {
     ipcRenderer.on(

--- a/renderer.js
+++ b/renderer.js
@@ -5,6 +5,9 @@ window.addEventListener('DOMContentLoaded', () => {
   })
   window.api.addListenerOnPythonMessage(onPythonMessage)
   window.api.addListenerOnPythonEnd(onPythonEnd)
+  document.getElementById('select_dir_button').addEventListener('click', (e) => {
+    onClickSelectDirButton()
+  })
 })
 
 /**
@@ -78,4 +81,9 @@ const onPythonMessage = (message) => {
   const element = document.createElement('li')
   element.innerText = "終了しました. 終了コード: " + code;
   resultListElem.appendChild(element)
+}
+
+const onClickSelectDirButton = async () => {
+  const filename = await window.api.selectDirectory();
+  console.log(filename);
 }

--- a/renderer.js
+++ b/renderer.js
@@ -1,5 +1,4 @@
 window.addEventListener('DOMContentLoaded', () => {
-  showFileList()
   document.getElementById('run_py_button').addEventListener('click', (e) => {
     onClickRunPythonButton()
   })
@@ -20,8 +19,14 @@ const onClickRunPythonButton = () => {
   window.api.runPy();
 }
 
-const showFileList = async () => {
-  const rootDir = "/tmp/sample";
+const onClickSelectDirButton = async () => {
+  const dirname = await window.api.selectDirectory();
+  if (dirname !== null) {
+    await showFileList(dirname);
+  }
+}
+
+const showFileList = async (rootDir) => {
   const fileList = await window.api.getImagesAndDirs(rootDir);
   const fileListElem = document.getElementById('file_list')
   fileList.forEach((file) => {
@@ -81,9 +86,4 @@ const onPythonMessage = (message) => {
   const element = document.createElement('li')
   element.innerText = "終了しました. 終了コード: " + code;
   resultListElem.appendChild(element)
-}
-
-const onClickSelectDirButton = async () => {
-  const filename = await window.api.selectDirectory();
-  console.log(filename);
 }


### PR DESCRIPTION
# 背景
選択したディレクトリのパスを取得し、それ以下のファイルも取得する

# エビデンス
<img width="912" alt="スクリーンショット 2021-12-07 1 08 25" src="https://user-images.githubusercontent.com/13075237/144881546-16a99ff5-be68-4b8c-a344-db93578425aa.png">

<img width="912" alt="スクリーンショット 2021-12-07 1 08 32" src="https://user-images.githubusercontent.com/13075237/144881535-5a45020f-92d4-49cf-b989-93a64cbe7cbd.png">

<img width="912" alt="スクリーンショット 2021-12-07 1 08 34" src="https://user-images.githubusercontent.com/13075237/144881530-5dc8baea-73c6-4040-9c3c-019d7ea26a19.png">

<img width="912" alt="スクリーンショット 2021-12-07 1 08 39" src="https://user-images.githubusercontent.com/13075237/144881504-4e30ccb1-33e2-4403-b242-9f6cfee05901.png">

